### PR TITLE
Set AWS Lambda runtime version to provided.al2.

### DIFF
--- a/terraform/lambda.tf
+++ b/terraform/lambda.tf
@@ -5,7 +5,7 @@ resource "aws_lambda_function" "rehydration_fargate_trigger_lambda" {
   function_name    = "${var.environment_name}-${var.service_name}-fargate-trigger-lambda-${data.terraform_remote_state.region.outputs.aws_region_shortname}"
   reserved_concurrent_executions = 1 // don't allow concurrent lambda's
   handler          = "bootstrap"
-  runtime          = "provided.al2023"
+  runtime          = "provided.al2"
   architectures    = ["arm64"]
   role             = aws_iam_role.rehydration_lambda_role.arn
   timeout          = 30


### PR DESCRIPTION
Reverts the Lambda runtime version to provided.al2.

The newer runtime, provided.al2023, is not recognized by the version of the Terraform AWS provider we are using in infrastructure.

provided.al2 is still a supported runtime, so there is no reason not to use it for now.