### PR TITLE
Fix DynamoDB Permissions

### DIFF
--- a/lambda/service/handler/handler.go
+++ b/lambda/service/handler/handler.go
@@ -81,5 +81,5 @@ func errorResponse(statusCode int, err error, lambdaRequest events.APIGatewayV2H
 		StatusCode: statusCode,
 		Headers:    map[string]string{"Content-Type": "application/json"},
 		Body:       errorBody(err, lambdaRequest),
-	}, err
+	}, nil
 }

--- a/terraform/iam.tf
+++ b/terraform/iam.tf
@@ -70,6 +70,25 @@ data "aws_iam_policy_document" "rehydration_fargate_iam_policy_document" {
       "${data.terraform_remote_state.platform_infrastructure.outputs.discover_publish50_bucket_arn}/*",
     ]
   }
+
+  statement {
+    sid    = "RehydrationFargateDynamoDBPermissions"
+    effect = "Allow"
+
+    actions = [
+      "dynamodb:UpdateItem",
+      "dynamodb:GetItem",
+      "dynamodb:PutItem",
+      "dynamodb:DeleteItem",
+    ]
+
+    resources = [
+      aws_dynamodb_table.idempotency_table.arn,
+      "${aws_dynamodb_table.idempotency_table.arn}/*",
+    ]
+
+  }
+
   statement {
     sid     = "TaskLogPermissions"
     effect  = "Allow"


### PR DESCRIPTION
Previous PR failed to give the Fargate task role permission to update the idempotency DynamoDB table.

This also changes the return of the Lambda trigger in case of error. We no longer return an error, and only put the error info in the Lambda response object so that API Gateway does not hide our custom error messages.