### PR TITLE
Fix Destination Key Bug

### DIFF
--- a/lambda/service/go.mod
+++ b/lambda/service/go.mod
@@ -37,7 +37,6 @@ require (
 	github.com/aws/smithy-go v1.19.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/jmespath/go-jmespath v0.4.0 // indirect
-	github.com/pennsieve/pennsieve-go v1.3.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/stretchr/objx v0.5.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/lambda/service/go.sum
+++ b/lambda/service/go.sum
@@ -57,8 +57,6 @@ github.com/jmespath/go-jmespath v0.4.0 h1:BEgLn5cpjn8UN1mAw4NjwDrS35OdebyEtFe+9Y
 github.com/jmespath/go-jmespath v0.4.0/go.mod h1:T8mJZnbsbmF+m6zOOFylbeCJqk5+pHWvzYPziyZiYoo=
 github.com/jmespath/go-jmespath/internal/testify v1.5.1 h1:shLQSRRSCCPj3f2gpwzGwWFoC7ycTf1rcQZHOlsJ6N8=
 github.com/jmespath/go-jmespath/internal/testify v1.5.1/go.mod h1:L3OGu8Wl2/fWfCI6z80xFu9LTZmf1ZRjMHUOPmWr69U=
-github.com/pennsieve/pennsieve-go v1.3.1 h1:BQNV0Jd6/+1B0s0z8Ewutro1+xap3jIQrx21oE0G0Mc=
-github.com/pennsieve/pennsieve-go v1.3.1/go.mod h1:9V1bnE2Rv4y0u3oiKSaSeULqqxW7Ta7sXwUp99zxlKc=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=

--- a/rehydrate/fargate/dataset.go
+++ b/rehydrate/fargate/dataset.go
@@ -77,12 +77,12 @@ func (dr *DatasetRehydrator) rehydrate(ctx context.Context) (*RehydrationResult,
 				Size:       datasetFileByVersionResponse.Size,
 				Name:       datasetFileByVersionResponse.Name,
 				VersionId:  datasetFileByVersionResponse.S3VersionID,
-				Path:       datasetFileByVersionResponse.Path},
+				Path:       j.Path},
 			DestinationObject{
 				Bucket: destinationBucket,
 				Key: utils.CreateDestinationKey(dr.dataset.ID,
 					dr.dataset.VersionID,
-					datasetFileByVersionResponse.Path),
+					j.Path),
 			}))
 	}
 	// Only submit rehydrations once we know there are no GetDatasetFileByVersion errors

--- a/rehydrate/fargate/dataset_test.go
+++ b/rehydrate/fargate/dataset_test.go
@@ -24,7 +24,7 @@ func TestRehydrate(t *testing.T) {
 	dataset := taskEnv.Dataset
 
 	datasetFileCount := 50
-	testDatasetFiles := NewTestDatasetFiles(*dataset, datasetFileCount)
+	testDatasetFiles := discovertest.NewTestDatasetFiles(*dataset, datasetFileCount)
 
 	for testName, testParams := range map[string]struct {
 		thresholdSize int64
@@ -49,7 +49,7 @@ func TestRehydrate(t *testing.T) {
 			mockDiscover := discovertest.NewServerFixture(t, nil,
 				discovertest.GetDatasetByVersionHandlerBuilder(*dataset, publishBucket),
 				discovertest.GetDatasetMetadataByVersionHandlerBuilder(*dataset, testDatasetFiles.DatasetFiles()),
-				discovertest.GetDatasetFileByVersionHandlerBuilder(*dataset, publishBucket, testDatasetFiles.DatasetFilesByPath()),
+				discovertest.GetDatasetFileByVersionHandlerBuilder(*dataset, publishBucket, testDatasetFiles.ByPath),
 			)
 			defer mockDiscover.Teardown()
 
@@ -88,7 +88,7 @@ func TestRehydrate_S3Errors(t *testing.T) {
 	dataset := taskEnv.Dataset
 
 	testDatasetFileCount := 1000
-	testDatasetFiles := NewTestDatasetFiles(*dataset, testDatasetFileCount).WithFakeS3VersionsIDs()
+	testDatasetFiles := discovertest.NewTestDatasetFiles(*dataset, testDatasetFileCount).WithFakeS3VersionsIDs()
 	var copyFailPaths []string
 	for i, file := range testDatasetFiles.Files {
 		// S3 Failure every 10th file
@@ -101,7 +101,7 @@ func TestRehydrate_S3Errors(t *testing.T) {
 	mockDiscover := discovertest.NewServerFixture(t, nil,
 		discovertest.GetDatasetByVersionHandlerBuilder(*dataset, publishBucket),
 		discovertest.GetDatasetMetadataByVersionHandlerBuilder(*dataset, testDatasetFiles.DatasetFiles()),
-		discovertest.GetDatasetFileByVersionHandlerBuilder(*dataset, publishBucket, testDatasetFiles.DatasetFilesByPath()),
+		discovertest.GetDatasetFileByVersionHandlerBuilder(*dataset, publishBucket, testDatasetFiles.ByPath),
 	)
 
 	defer mockDiscover.Teardown()
@@ -137,7 +137,7 @@ func TestRehydrate_DiscoverErrors(t *testing.T) {
 	taskEnv := newTestConfigEnv()
 	dataset := taskEnv.Dataset
 
-	testDatasetFiles := NewTestDatasetFiles(*dataset, 50).WithFakeS3VersionsIDs()
+	testDatasetFiles := discovertest.NewTestDatasetFiles(*dataset, 50).WithFakeS3VersionsIDs()
 	pathsToFail := map[string]bool{testDatasetFiles.Files[24].Path: true}
 
 	for testName, testParams := range map[string]struct {

--- a/rehydrate/fargate/go.mod
+++ b/rehydrate/fargate/go.mod
@@ -8,7 +8,6 @@ require (
 	github.com/aws/aws-sdk-go v1.45.23
 	github.com/aws/aws-sdk-go-v2 v1.24.1
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.48.1
-	github.com/google/uuid v1.3.0
 	github.com/pennsieve/pennsieve-go v1.3.1
 	github.com/pennsieve/rehydration-service/shared v0.0.0-00010101000000-000000000000
 	github.com/stretchr/testify v1.8.4
@@ -41,6 +40,7 @@ require (
 	github.com/aws/smithy-go v1.19.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/golang-jwt/jwt v3.2.2+incompatible // indirect
+	github.com/google/uuid v1.6.0 // indirect
 	github.com/jmespath/go-jmespath v0.4.0 // indirect
 	github.com/pennsieve/pennsieve-go-api v1.1.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect

--- a/rehydrate/fargate/go.sum
+++ b/rehydrate/fargate/go.sum
@@ -63,8 +63,8 @@ github.com/golang-jwt/jwt v3.2.2+incompatible h1:IfV12K8xAKAnZqdXVzCZ+TOjboZ2keL
 github.com/golang-jwt/jwt v3.2.2+incompatible/go.mod h1:8pz2t5EyA70fFQQSrl6XZXzqecmYZeUEB8OUGHkxJ+I=
 github.com/google/go-cmp v0.5.8 h1:e6P7q2lk1O+qJJb4BtCQXlK8vWEO8V1ZeuEdJNOqZyg=
 github.com/google/go-cmp v0.5.8/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
-github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
-github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
+github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/jmespath/go-jmespath v0.4.0 h1:BEgLn5cpjn8UN1mAw4NjwDrS35OdebyEtFe+9YPoQUg=
 github.com/jmespath/go-jmespath v0.4.0/go.mod h1:T8mJZnbsbmF+m6zOOFylbeCJqk5+pHWvzYPziyZiYoo=
 github.com/jmespath/go-jmespath/internal/testify v1.5.1 h1:shLQSRRSCCPj3f2gpwzGwWFoC7ycTf1rcQZHOlsJ6N8=

--- a/rehydrate/shared/go.mod
+++ b/rehydrate/shared/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.48.1
 	github.com/aws/aws-sdk-go-v2/service/sqs v1.29.7
 	github.com/aws/smithy-go v1.19.0
+	github.com/google/uuid v1.6.0
 	github.com/pennsieve/pennsieve-go v1.3.1
 	github.com/stretchr/testify v1.8.4
 )

--- a/rehydrate/shared/go.sum
+++ b/rehydrate/shared/go.sum
@@ -51,6 +51,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/google/go-cmp v0.5.8 h1:e6P7q2lk1O+qJJb4BtCQXlK8vWEO8V1ZeuEdJNOqZyg=
 github.com/google/go-cmp v0.5.8/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
+github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/jmespath/go-jmespath v0.4.0 h1:BEgLn5cpjn8UN1mAw4NjwDrS35OdebyEtFe+9YPoQUg=
 github.com/jmespath/go-jmespath v0.4.0/go.mod h1:T8mJZnbsbmF+m6zOOFylbeCJqk5+pHWvzYPziyZiYoo=
 github.com/jmespath/go-jmespath/internal/testify v1.5.1 h1:shLQSRRSCCPj3f2gpwzGwWFoC7ycTf1rcQZHOlsJ6N8=

--- a/rehydrate/shared/test/discovertest/discover_test.go
+++ b/rehydrate/shared/test/discovertest/discover_test.go
@@ -1,0 +1,23 @@
+package discovertest
+
+import (
+	"github.com/pennsieve/rehydration-service/shared/models"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestNewTestDatasetFiles(t *testing.T) {
+	testDatasetFiles := NewTestDatasetFiles(models.Dataset{
+		ID:        1,
+		VersionID: 2,
+	}, 1).WithFakeS3VersionsIDs()
+
+	files := testDatasetFiles.Files
+
+	for i := 0; i < len(files); i++ {
+		byPath := testDatasetFiles.ByPath[files[i].Path]
+		assert.Same(t, &files[i], byPath)
+		assert.NotEmpty(t, files[i].S3VersionID)
+		assert.Equal(t, files[i].S3VersionID, byPath.S3VersionID)
+	}
+}


### PR DESCRIPTION
Changes in  #18 resulted in destination keys with duplicate nested datasetIds: eg., `5069/1/5069/files/....` because it did not realize that the `path` returned by `/datasets/x/version/y/files` is an S3 key, and so already included the datasetId.