### PR TITLE
Fix Fargate DynamoDB Permissions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /.idea/
 /lambda/bin/
+/node_modules/

--- a/terraform/iam.tf
+++ b/terraform/iam.tf
@@ -80,6 +80,7 @@ data "aws_iam_policy_document" "rehydration_fargate_iam_policy_document" {
       "dynamodb:GetItem",
       "dynamodb:PutItem",
       "dynamodb:DeleteItem",
+      "dynamodb:Query",
     ]
 
     resources = [


### PR DESCRIPTION
The Fargate task needs the `Query` permission on DynamoDB.