### PR TITLE
Email fixes

### DIFF
--- a/lambda/service/handler/handler_test.go
+++ b/lambda/service/handler/handler_test.go
@@ -340,6 +340,7 @@ func TestRehydrationServiceHandler_BadRequests(t *testing.T) {
 		"missing datasetVersionId": {requestToBody(t, models.Request{Dataset: sharedmodels.Dataset{ID: 3879}, User: sharedmodels.User{Name: "First Last", Email: "last@example.com"}}), "datasetVersionId"},
 		"empty name":               {requestToBody(t, models.Request{Dataset: sharedmodels.Dataset{ID: 3879, VersionID: 4}, User: sharedmodels.User{Email: "last@example.com"}}), "name"},
 		"empty email":              {requestToBody(t, models.Request{Dataset: sharedmodels.Dataset{ID: 3879, VersionID: 4}, User: sharedmodels.User{Name: "First Last"}}), "email"},
+		"invalid email":            {requestToBody(t, models.Request{Dataset: sharedmodels.Dataset{ID: 3879, VersionID: 4}, User: sharedmodels.User{Name: "First Last", Email: "invalid&address"}}), "email"},
 	} {
 		t.Run(name, func(t *testing.T) {
 			ctx := context.Background()

--- a/lambda/service/request/request.go
+++ b/lambda/service/request/request.go
@@ -13,6 +13,7 @@ import (
 	"github.com/pennsieve/rehydration-service/shared/notification"
 	"github.com/pennsieve/rehydration-service/shared/tracking"
 	"log/slog"
+	"net/mail"
 	"time"
 )
 
@@ -47,6 +48,9 @@ func validateRequest(request models.Request) *BadRequestError {
 	}
 	if len(request.User.Email) == 0 {
 		return &BadRequestError{`missing User "email"`}
+	}
+	if _, err := mail.ParseAddress(request.User.Email); err != nil {
+		return &BadRequestError{message: fmt.Sprintf("invalid email address: %s: %v", request.User.Email, err)}
 	}
 	return nil
 }

--- a/message-templates/mjml/rehydration-failed.mjml
+++ b/message-templates/mjml/rehydration-failed.mjml
@@ -71,6 +71,7 @@
     <mj-section mj-class="copy-section">
       <mj-column padding="24px 0 0">
         <mj-text mj-class="kicker">
+          Click <a href="mailto:{{.SupportEmailAddress}}?subject=Rehydration%20request%20{{.RequestID}}">here</a> to contact Pennsieve Support about this error.
           When reporting the error please include your request ID: <code>{{.RequestID}}</code>
         </mj-text>
       </mj-column>

--- a/rehydrate/shared/notification/html/rehydration-failed.html
+++ b/rehydrate/shared/notification/html/rehydration-failed.html
@@ -191,7 +191,7 @@
                           <tbody>
                             <tr>
                               <td align="left" style="font-size:0px;padding:0;word-break:break-word;">
-                                <div style="font-family:-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen-Sans, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif;font-size:16px;line-height:24px;text-align:left;color:#000000;">When reporting the error please include your request ID: <code>{{.RequestID}}</code></div>
+                                <div style="font-family:-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen-Sans, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif;font-size:16px;line-height:24px;text-align:left;color:#000000;">Click <a href="mailto:{{.SupportEmailAddress}}?subject=Rehydration%20request%20{{.RequestID}}">here</a> to contact Pennsieve Support about this error. When reporting the error please include your request ID: <code>{{.RequestID}}</code></div>
                               </td>
                             </tr>
                           </tbody>

--- a/rehydrate/shared/notification/ses.go
+++ b/rehydrate/shared/notification/ses.go
@@ -51,7 +51,7 @@ func (e *SESEmailer) SendRehydrationComplete(ctx context.Context, dataset models
 }
 
 func (e *SESEmailer) SendRehydrationFailed(ctx context.Context, dataset models.Dataset, user models.User, requestID string) error {
-	body, err := RehydrationFailedEmailBody(dataset.ID, dataset.VersionID, requestID)
+	body, err := RehydrationFailedEmailBody(dataset.ID, dataset.VersionID, requestID, e.sender)
 	if err != nil {
 		return err
 	}

--- a/rehydrate/shared/notification/templates.go
+++ b/rehydrate/shared/notification/templates.go
@@ -29,9 +29,10 @@ type rehydrationCompleteData struct {
 }
 
 type rehydrationFailedData struct {
-	DatasetID        int
-	DatasetVersionID int
-	RequestID        string
+	DatasetID           int
+	DatasetVersionID    int
+	RequestID           string
+	SupportEmailAddress string
 }
 
 func parseTemplate(pattern string) (*template.Template, error) {
@@ -60,11 +61,12 @@ func RehydrationCompleteEmailBody(datasetID, datasetVersionID int, rehydrationLo
 	})
 }
 
-func RehydrationFailedEmailBody(datasetID, datasetVersionID int, requestID string) (string, error) {
+func RehydrationFailedEmailBody(datasetID, datasetVersionID int, requestID string, supportEmailAddress string) (string, error) {
 	return executeTemplate(rehydrationFailedTemplate, rehydrationFailedData{
-		DatasetID:        datasetID,
-		DatasetVersionID: datasetVersionID,
-		RequestID:        requestID,
+		DatasetID:           datasetID,
+		DatasetVersionID:    datasetVersionID,
+		RequestID:           requestID,
+		SupportEmailAddress: supportEmailAddress,
 	})
 }
 

--- a/rehydrate/shared/notification/templates_test.go
+++ b/rehydrate/shared/notification/templates_test.go
@@ -35,10 +35,13 @@ func TestRehydrationFailedEmailBody(t *testing.T) {
 	datasetID := 6803
 	datasetVersionID := 1
 	requestID := uuid.NewString()
+	supportEmail := "support@pennsieve.example.com"
 
-	body, err := RehydrationFailedEmailBody(datasetID, datasetVersionID, requestID)
+	body, err := RehydrationFailedEmailBody(datasetID, datasetVersionID, requestID, supportEmail)
 	require.NoError(t, err)
 	assert.Contains(t, body, "Rehydration Failed")
 	assert.Contains(t, body, requestID)
 	assert.Contains(t, body, fmt.Sprintf("Dataset %d version %d", datasetID, datasetVersionID))
+	assert.Contains(t, body, fmt.Sprintf("mailto:%s", supportEmail))
+	assert.Contains(t, body, fmt.Sprintf("subject=Rehydration%%20request%%20%s", requestID))
 }


### PR DESCRIPTION
Adds a `mailto` link to the email sent upon rehydration failure. Link pre-populates the email subject with the user's request ID.

Also adds email validation to the service Lambda, so that requests with an invalid email format are rejected with a BadRequest response.