### PR TITLE
Fix for the location of rehydration bucket's S3 access logs

### DIFF
--- a/terraform/s3.tf
+++ b/terraform/s3.tf
@@ -62,5 +62,5 @@ resource "aws_s3_bucket_logging" "rehydration_s3_logging" {
   bucket = aws_s3_bucket.rehydration_s3_bucket.id
 
   target_bucket = data.terraform_remote_state.platform_infrastructure.outputs.discover_publish_logs_s3_bucket_id
-  target_prefix = local.discover_publish_logs_target_prefix
+  target_prefix = local.rehydration_logs_target_prefix
 }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -45,8 +45,8 @@ locals {
   domain_name = data.terraform_remote_state.account.outputs.domain_name
   hosted_zone = data.terraform_remote_state.account.outputs.public_hosted_zone_id
 
-  rehydration_bucket_name             = "pennsieve-${var.environment_name}-rehydration-${data.terraform_remote_state.region.outputs.aws_region_shortname}"
-  discover_publish_logs_target_prefix = "${var.environment_name}/discover-publish/s3/"
+  rehydration_bucket_name        = "pennsieve-${var.environment_name}-rehydration-${data.terraform_remote_state.region.outputs.aws_region_shortname}"
+  rehydration_logs_target_prefix = "${var.environment_name}/rehydration/s3/"
 
   common_tags = {
     aws_account      = var.aws_account


### PR DESCRIPTION
PR changes the S3 key prefix which determines where the S3 access logs for the rehydration bucket are placed in the log bucket.

Currently they are sent to the same location as the publish bucket's logs. But because of the difference in key format between publish (`datasetId/`) and rehydration (`datasetId/version/`) having the access logs for both buckets in the same location will cause problems with the Athena query used to track downloads from the publish bucket.