### PR TITLE
Fix rehydration S3 errors

### DIFF
--- a/rehydrate/fargate/main.go
+++ b/rehydrate/fargate/main.go
@@ -40,7 +40,7 @@ func main() {
 
 	taskConfig.Logger.Info("starting rehydration task")
 	if err := RehydrationTaskHandler(ctx, taskHandler); err != nil {
-		taskConfig.Logger.Error("error rehydrating dataset: %v", err)
+		taskConfig.Logger.Error("error rehydrating dataset", slog.Any("error", err))
 		os.Exit(1)
 	}
 	taskConfig.Logger.Info("rehydration complete")

--- a/rehydrate/fargate/utils/multipartUpload_test.go
+++ b/rehydrate/fargate/utils/multipartUpload_test.go
@@ -1,0 +1,72 @@
+package utils
+
+import (
+	"context"
+	"fmt"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/pennsieve/rehydration-service/shared/logging"
+	"github.com/pennsieve/rehydration-service/shared/test"
+	"github.com/stretchr/testify/require"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestMultiPartCopy(t *testing.T) {
+	//logging.Level.Set(slog.LevelDebug)
+	// set a lower chunkSize for the test
+	chunkSize = 5242880
+	ctx := context.Background()
+	awsConfig := test.NewAWSEndpoints(t).WithMinIO().Config(ctx, false)
+	sourceBucket := "test-source-bucket"
+	sourceKey := "13/files/test-file.dat"
+	targetBucket := "test-target-bucket"
+	targetKey := "13/2/files/test-file.dat"
+
+	testFile := openTestFile(t, "multipart-upload-test.dat")
+	defer func() {
+		require.NoError(t, testFile.Close())
+	}()
+	testFileInfo, err := testFile.Stat()
+	require.NoError(t, err)
+	testFileSize := testFileInfo.Size()
+
+	s3Fixture, putObjectOuts := test.NewS3Fixture(t,
+		s3.NewFromConfig(awsConfig),
+		&s3.CreateBucketInput{Bucket: aws.String(sourceBucket)},
+		&s3.CreateBucketInput{Bucket: aws.String(targetBucket)}).
+		WithVersioning(sourceBucket).
+		WithObjects(&s3.PutObjectInput{
+			Bucket:        aws.String(sourceBucket),
+			Key:           aws.String(sourceKey),
+			Body:          testFile,
+			ContentLength: aws.Int64(testFileSize),
+		})
+	defer s3Fixture.Teardown()
+
+	putObjectOut, ok := putObjectOuts[test.S3Location{
+		Bucket: sourceBucket,
+		Key:    sourceKey,
+	}]
+	require.True(t, ok)
+	require.NotNil(t, putObjectOut.VersionId)
+
+	copySource := fmt.Sprintf("%s/%s?versionId%s", sourceBucket, sourceKey, aws.ToString(putObjectOut.VersionId))
+	require.NoError(t,
+		MultiPartCopy(s3Fixture.Client,
+			testFileSize,
+			copySource,
+			targetBucket,
+			targetKey,
+			logging.Default))
+
+	s3Fixture.AssertObjectExists(targetBucket, targetKey, testFileSize)
+}
+
+func openTestFile(t *testing.T, name string) *os.File {
+	filePath := filepath.Join("testdata", name)
+	file, err := os.Open(filePath)
+	require.NoError(t, err)
+	return file
+}

--- a/terraform/iam.tf
+++ b/terraform/iam.tf
@@ -52,7 +52,7 @@ data "aws_iam_policy_document" "rehydration_fargate_iam_policy_document" {
     effect = "Allow"
 
     actions = [
-      "s3:GetObject",
+      "s3:Get*",
     ]
 
     resources = [


### PR DESCRIPTION
Fixes a few errors found in rehydration

- Having only the `s3:GetObject` permission on the publish buckets worked for the Pennsieve bucket, but was not enough for SPARC. Added all `s3:Get*` to keep it read-only.
- Fix a logic error in assigning multipart copy `PartNumber`s that resulted in all parts having the same number.
- Added missing bucket and key parameters in the `AbortMultipartUpload` input struct.
- Fixed a logging bug
- Added a test for multipart copy