### PR TITLE
Fix: Cron Expression for Expiration

### DIFF
--- a/terraform/cloudwatch.tf
+++ b/terraform/cloudwatch.tf
@@ -50,7 +50,7 @@ resource "aws_cloudwatch_log_subscription_filter" "expiration_lambda_datadog_sub
 resource "aws_cloudwatch_event_rule" "expiration_cloudwatch_event_rule" {
   name                = "${var.environment_name}-rehydration-expiration-cloudwatch-event-rule-${data.terraform_remote_state.region.outputs.aws_region_shortname}"
   description         = "Daily trigger for rehydration expiration"
-  schedule_expression = "cron(0 4 * * * *)"
+  schedule_expression = "cron(0 4 * * ? *)"
 }
 
 resource "aws_cloudwatch_event_target" "expiration_cloudwatch_event_target" {


### PR DESCRIPTION
Fixes incorrect syntax on cron expression:

[You can't specify the Day-of-month and Day-of-week fields in the same cron expression. If you specify a value or a * (asterisk) in one of the fields, you must use a ? (question mark) in the other.](https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-cron-expressions.html)