### PR TITLE
Fix: rehydration location should end with a slash

### DIFF
--- a/rehydrate/fargate/utils/utils.go
+++ b/rehydrate/fargate/utils/utils.go
@@ -7,7 +7,7 @@ import (
 )
 
 func RehydrationLocation(destinationBucket string, datasetID, datasetVersionID int) string {
-	return fmt.Sprintf("s3://%s", path.Join(destinationBucket, DestinationKeyPrefix(datasetID, datasetVersionID)))
+	return fmt.Sprintf("s3://%s/%s", destinationBucket, DestinationKeyPrefix(datasetID, datasetVersionID))
 }
 func DestinationKeyPrefix(datasetID, datasetVersionID int) string {
 	return fmt.Sprintf("%d/%d/", datasetID, datasetVersionID)

--- a/rehydrate/fargate/utils/utils_test.go
+++ b/rehydrate/fargate/utils/utils_test.go
@@ -34,7 +34,7 @@ func TestRehydrationLocation(t *testing.T) {
 	destinationBucket := "destination-bucket"
 	datasetId := 5070
 	versionId := 2
-	expectedLocation := fmt.Sprintf("s3://%s/%d/%d", destinationBucket, datasetId, versionId)
+	expectedLocation := fmt.Sprintf("s3://%s/%d/%d/", destinationBucket, datasetId, versionId)
 	location := utils.RehydrationLocation(destinationBucket, datasetId, versionId)
 	require.Equal(t, expectedLocation, location)
 }


### PR DESCRIPTION
PR fixes the utility method used to construct rehydration location values that are stored in DynamoDB. These URLs should end in a slash, so `s3://bucket/x/y/` and not `s3://bucket/x/y`. But current version uses `path.Join` which strips the final slash.

The final slash is in keeping with how we usually display `s3://` URLs for Discover datasets and is also required by `s3cleaner.Cleaner` as a safety measure. (Cleaning prefix `5045/1` would clean both `5045/1/` and `5045/10/` for example.)