### PR TITLE
fix: escapes path with special characters

### DIFF
--- a/fargate/rehydrate/go.mod
+++ b/fargate/rehydrate/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/config v1.15.7
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.40.0
 	github.com/pennsieve/pennsieve-go v1.3.1
+	github.com/stretchr/testify v1.8.0
 )
 
 require (
@@ -27,6 +28,9 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/sso v1.11.5 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sts v1.16.6 // indirect
 	github.com/aws/smithy-go v1.14.2 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/golang-jwt/jwt v3.2.2+incompatible // indirect
 	github.com/pennsieve/pennsieve-go-api v1.1.0 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/fargate/rehydrate/go.sum
+++ b/fargate/rehydrate/go.sum
@@ -66,6 +66,8 @@ github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINE
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
+github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.0 h1:pSgiaMZlXftHpm5L7V1+rVB+AZJydKsMxsQBIJw4PKk=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
@@ -96,7 +98,9 @@ golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtn
 golang.org/x/tools v0.1.12/go.mod h1:hNGJHUnrk76NpqgfD5Aqm5Crs+Hm0VOH/i9J2+nxYbc=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/fargate/rehydrate/utils/utils.go
+++ b/fargate/rehydrate/utils/utils.go
@@ -6,6 +6,9 @@ import (
 	"net/url"
 	"os"
 	"strconv"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/smithy-go/encoding/httpbinding"
 )
 
 func CreateDestinationKey(datasetId int32, versionId int32, path string) string {
@@ -34,4 +37,16 @@ func GetApiHost(env string) string {
 	} else {
 		return "https://api.pennsieve.io"
 	}
+}
+
+func CreateAWSEscapedPath(s string) *string {
+	// Trial and error has shown that the encoding done by httpbinding.EscapePath works better
+	// with S3 than either url.PathEscape() or url.Parse().EscapedPath(). Those net/url methods
+	// resulted in 404 copy failures for some tricky file names.
+	escapedPath := httpbinding.EscapePath(s, false)
+	return aws.String(escapedPath)
+}
+
+func CreateURLEscapedPath(s string) string {
+	return url.QueryEscape(s)
 }

--- a/fargate/rehydrate/utils/utils_test.go
+++ b/fargate/rehydrate/utils/utils_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/pennsieve/rehydration-service/rehydrate/utils"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestCreateDestinationKey(t *testing.T) {
@@ -37,4 +38,26 @@ func TestCreateVersionedSource(t *testing.T) {
 	if result != expectedResult {
 		t.Errorf("got %s, expected %s", result, expectedResult)
 	}
+}
+
+func TestCreateURLEscapedPath(t *testing.T) {
+	path := "files/primary/sub-P786/P786 Embedding Schematic.pptx"
+	result := utils.CreateURLEscapedPath(path)
+	assert.Equal(t, result, "files%2Fprimary%2Fsub-P786%2FP786+Embedding+Schematic.pptx")
+
+	// paths not requiring url encoding are left as-is
+	path = "P786EmbeddingSchematic.pptx"
+	result = utils.CreateURLEscapedPath(path)
+	assert.Equal(t, result, "P786EmbeddingSchematic.pptx")
+}
+
+func TestCreateAWSEscapedPath(t *testing.T) {
+	path := "files/primary/sub-P786/P786 Embedding Schematic.pptx"
+	result := utils.CreateAWSEscapedPath(path)
+	assert.Equal(t, *result, "files/primary/sub-P786/P786%20Embedding%20Schematic.pptx")
+
+	// paths not requiring url encoding are left as-is
+	path = "files/primary/sub-P786/P786EmbeddingSchematic.pptx"
+	result = utils.CreateAWSEscapedPath(path)
+	assert.Equal(t, *result, "files/primary/sub-P786/P786EmbeddingSchematic.pptx")
 }


### PR DESCRIPTION
Addresses:
- https://app.clickup.com/t/8689pdnrq

This MR escapes the source path for:
- retrieving the dataset version by file (URL escaping)
- copying the source to the destination (AWS path escaping)
