### PR TITLE
fix: escapes path with special characters

### DIFF
--- a/rehydrate/fargate/utils/utils.go
+++ b/rehydrate/fargate/utils/utils.go
@@ -4,6 +4,9 @@ import (
 	"fmt"
 	"net/url"
 	"path"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/smithy-go/encoding/httpbinding"
 )
 
 func RehydrationLocation(destinationBucket string, datasetID, datasetVersionID int) string {
@@ -31,4 +34,15 @@ func GetApiHost(env string) string {
 
 	}
 	return "https://api.pennsieve.net"
+}
+
+func CreateAWSEscapedPath(s string) *string {
+	// Trial and error has shown that the encoding done by httpbinding.EscapePath works better
+	// with S3 than either url.PathEscape() or url.Parse().EscapedPath(). Those net/url methods
+	// resulted in 404 copy failures for some tricky file names.
+	escapedPath := httpbinding.EscapePath(s, false)
+	return aws.String(escapedPath)
+}
+func CreateURLEscapedPath(s string) string {
+	return url.QueryEscape(s)
 }

--- a/rehydrate/fargate/utils/utils_test.go
+++ b/rehydrate/fargate/utils/utils_test.go
@@ -2,8 +2,10 @@ package utils_test
 
 import (
 	"fmt"
-	"github.com/stretchr/testify/require"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/pennsieve/rehydration-service/fargate/utils"
 )
@@ -37,4 +39,14 @@ func TestRehydrationLocation(t *testing.T) {
 	expectedLocation := fmt.Sprintf("s3://%s/%d/%d/", destinationBucket, datasetId, versionId)
 	location := utils.RehydrationLocation(destinationBucket, datasetId, versionId)
 	require.Equal(t, expectedLocation, location)
+}
+
+func TestCreateURLEscapedPath(t *testing.T) {
+	path := "files/primary/sub-P786/P786 Embedding Schematic.pptx"
+	result := utils.CreateURLEscapedPath(path)
+	assert.Equal(t, result, "files%2Fprimary%2Fsub-P786%2FP786+Embedding+Schematic.pptx")
+	// paths not requiring url encoding are left as-is
+	path = "P786EmbeddingSchematic.pptx"
+	result = utils.CreateURLEscapedPath(path)
+	assert.Equal(t, result, "P786EmbeddingSchematic.pptx")
 }

--- a/rehydrate/fargate/utils/utils_test.go
+++ b/rehydrate/fargate/utils/utils_test.go
@@ -50,3 +50,14 @@ func TestCreateURLEscapedPath(t *testing.T) {
 	result = utils.CreateURLEscapedPath(path)
 	assert.Equal(t, result, "P786EmbeddingSchematic.pptx")
 }
+
+func TestCreateAWSEscapedPath(t *testing.T) {
+	path := "files/primary/sub-P786/P786 Embedding Schematic.pptx"
+	result := utils.CreateAWSEscapedPath(path)
+	assert.Equal(t, *result, "files/primary/sub-P786/P786%20Embedding%20Schematic.pptx")
+
+	// paths not requiring url encoding are left as-is
+	path = "files/primary/sub-P786/P786EmbeddingSchematic.pptx"
+	result = utils.CreateAWSEscapedPath(path)
+	assert.Equal(t, *result, "files/primary/sub-P786/P786EmbeddingSchematic.pptx")
+}


### PR DESCRIPTION
Addresses: https://app.clickup.com/t/8689pdnrq

This MR escapes the source path for:

retrieving the dataset version by file (URL escaping)
copying the source to the destination (AWS path escaping)